### PR TITLE
fix compile failure on v141_xp c++17

### DIFF
--- a/rapidfuzz/distance/LCSseq_impl.hpp
+++ b/rapidfuzz/distance/LCSseq_impl.hpp
@@ -221,7 +221,7 @@ auto lcs_unroll(const PMV& block, const Range<InputIt1>&, const Range<InputIt2>&
 
         static constexpr size_t unroll_factor = 3;
         for (unsigned int j = 0; j < N / unroll_factor; ++j) {
-            unroll<size_t, unroll_factor>([&](size_t word_) {
+            unroll<size_t, unroll_factor>([&res, &S, &j, &iter_s2, &carry, &block, &i](size_t word_) {
                 size_t word = word_ + j * unroll_factor;
                 uint64_t Matches = block.get(word, *iter_s2);
                 uint64_t u = S[word] & Matches;
@@ -235,7 +235,7 @@ auto lcs_unroll(const PMV& block, const Range<InputIt1>&, const Range<InputIt2>&
             });
         }
 
-        unroll<size_t, N % unroll_factor>([&](size_t word_) {
+        unroll<size_t, N % unroll_factor>([&res, &S, &carry, &block, &i, &iter_s2](size_t word_) {
             size_t word = word_ + N / unroll_factor * unroll_factor;
             uint64_t Matches = block.get(word, *iter_s2);
             uint64_t u = S[word] & Matches;

--- a/rapidfuzz/distance/Levenshtein_impl.hpp
+++ b/rapidfuzz/distance/Levenshtein_impl.hpp
@@ -696,7 +696,7 @@ auto levenshtein_hyrroe2003_block(const BlockPatternMatchVector& PM, const Range
             res_.VN.set_offset(row, static_cast<ptrdiff_t>(first_block * word_size));
         }
 
-        auto advance_block = [&](size_t word) {
+        auto advance_block = [&res, &row, &PM, &words, &vecs, &Last, &iter_s2, &HP_carry, &HN_carry, &first_block](size_t word) {
             /* Step 1: Computing D0 */
             uint64_t PM_j = PM.get(word, *iter_s2);
             uint64_t VN = vecs[word].VN;


### PR DESCRIPTION
Explicitly declaring the referenced variables or removing the following constexpr ( [1](https://github.com/rapidfuzz/rapidfuzz-cpp/blob/main/rapidfuzz/distance/Levenshtein_impl.hpp#L730) [2](https://github.com/rapidfuzz/rapidfuzz-cpp/blob/main/rapidfuzz/distance/LCSseq_impl.hpp#L231) [3](https://github.com/rapidfuzz/rapidfuzz-cpp/blob/main/rapidfuzz/distance/LCSseq_impl.hpp#L245) ) can both result in successful compilation. Perhaps there are some bugs on the old compiler that I cannot understand
```
RAPIDFUZZ_IF_CONSTEXPR (RecordMatrix) {//replace RAPIDFUZZ_IF_CONSTEXPR as if can compile success
                    auto& res_ = getMatrixRef(res);
                   ......
```

details:

重新生成开始于 15:40...
1>------ 已启动全部重新生成: 项目: ConsoleApplication1, 配置: Release Win32 ------
1>C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v150\Platforms\Win32\PlatformToolsets\v141_xp\Toolset.targets(39,5): warning MSB8051: 面向 Windows XP 的支持已被弃用，将来的 Visual Studio 版本不再提供该支持。请访问 https://go.microsoft.com/fwlink/?linkid=2023588，获取详细信息。
1>FileName.cpp
1>c:\users\11737\documents\github\rapidfuzz-cpp\rapidfuzz\distance\levenshtein_impl.hpp(731): error C2065: “res”: 未声明的标识符
1>c:\users\11737\documents\github\rapidfuzz-cpp\rapidfuzz\distance\levenshtein_impl.hpp(888): note: 参见对正在编译的函数 模板 实例化“rapidfuzz::detail::LevenshteinResult<false,false> rapidfuzz::detail::levenshtein_hyrroe2003_block<false,false,std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>,std::_String_const_iterator<std::_String_val<std::_Simple_types<_Ty>>>>(const rapidfuzz::detail::BlockPatternMatchVector &,const rapidfuzz::detail::Range<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>> &,const rapidfuzz::detail::Range<std::_String_const_iterator<std::_String_val<std::_Simple_types<_Ty>>>> &,size_t,size_t)”的引用
1>        with
1>        [
1>            _Ty=wchar_t
1>        ]
1>c:\users\11737\documents\github\rapidfuzz-cpp\rapidfuzz\distance\levenshtein.hpp(458): note: 参见对正在编译的函数 模板 实例化“size_t rapidfuzz::detail::uniform_levenshtein_distance<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>,std::_String_const_iterator<std::_String_val<std::_Simple_types<_Ty>>>>(const rapidfuzz::detail::BlockPatternMatchVector &,rapidfuzz::detail::Range<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>>,rapidfuzz::detail::Range<std::_String_const_iterator<std::_String_val<std::_Simple_types<_Ty>>>>,size_t,size_t)”的引用
1>        with
1>        [
1>            _Ty=wchar_t
1>        ]
1>c:\users\11737\documents\github\rapidfuzz-cpp\rapidfuzz\details\distance.hpp(249): note: 参见对正在编译的函数 模板 实例化“size_t rapidfuzz::CachedLevenshtein<wchar_t>::_distance<std::_String_const_iterator<std::_String_val<std::_Simple_types<_Ty>>>>(const rapidfuzz::detail::Range<std::_String_const_iterator<std::_String_val<std::_Simple_types<_Ty>>>> &,size_t,size_t) const”的引用
1>        with
1>        [
1>            _Ty=wchar_t
1>        ]
1>c:\users\11737\documents\github\rapidfuzz-cpp\rapidfuzz\details\distance.hpp(249): note: 参见对正在编译的函数 模板 实例化“size_t rapidfuzz::CachedLevenshtein<wchar_t>::_distance<std::_String_const_iterator<std::_String_val<std::_Simple_types<_Ty>>>>(const rapidfuzz::detail::Range<std::_String_const_iterator<std::_String_val<std::_Simple_types<_Ty>>>> &,size_t,size_t) const”的引用
1>        with
1>        [
1>            _Ty=wchar_t
1>        ]
1>c:\users\11737\documents\github\rapidfuzz-cpp\rapidfuzz\details\distance.hpp(259): note: 参见对正在编译的函数 模板 实例化“double rapidfuzz::detail::CachedNormalizedMetricBase<T>::_normalized_distance<std::_String_const_iterator<std::_String_val<std::_Simple_types<_Ty>>>>(const rapidfuzz::detail::Range<std::_String_const_iterator<std::_String_val<std::_Simple_types<_Ty>>>> &,double,double) const”的引用
1>        with
1>        [
1>            T=rapidfuzz::CachedLevenshtein<wchar_t>,
1>            _Ty=wchar_t
1>        ]
1>c:\users\11737\documents\github\rapidfuzz-cpp\rapidfuzz\details\distance.hpp(259): note: 参见对正在编译的函数 模板 实例化“double rapidfuzz::detail::CachedNormalizedMetricBase<T>::_normalized_distance<std::_String_const_iterator<std::_String_val<std::_Simple_types<_Ty>>>>(const rapidfuzz::detail::Range<std::_String_const_iterator<std::_String_val<std::_Simple_types<_Ty>>>> &,double,double) const”的引用
1>        with
1>        [
1>            T=rapidfuzz::CachedLevenshtein<wchar_t>,
1>            _Ty=wchar_t
1>        ]
1>c:\users\11737\documents\github\rapidfuzz-cpp\rapidfuzz\details\distance.hpp(236): note: 参见对正在编译的函数 模板 实例化“double rapidfuzz::detail::CachedNormalizedMetricBase<T>::_normalized_similarity<std::_String_const_iterator<std::_String_val<std::_Simple_types<_Ty>>>>(const rapidfuzz::detail::Range<std::_String_const_iterator<std::_String_val<std::_Simple_types<_Ty>>>> &,double,double) const”的引用
1>        with
1>        [
1>            T=rapidfuzz::CachedLevenshtein<wchar_t>,
1>            _Ty=wchar_t
1>        ]
1>c:\users\11737\documents\github\rapidfuzz-cpp\rapidfuzz\details\distance.hpp(236): note: 参见对正在编译的函数 模板 实例化“double rapidfuzz::detail::CachedNormalizedMetricBase<T>::_normalized_similarity<std::_String_const_iterator<std::_String_val<std::_Simple_types<_Ty>>>>(const rapidfuzz::detail::Range<std::_String_const_iterator<std::_String_val<std::_Simple_types<_Ty>>>> &,double,double) const”的引用
1>        with
1>        [
1>            T=rapidfuzz::CachedLevenshtein<wchar_t>,
1>            _Ty=wchar_t
1>        ]
1>c:\users\11737\source\repos\consoleapplication1\filename.cpp(17): note: 参见对正在编译的函数 模板 实例化“double rapidfuzz::detail::CachedNormalizedMetricBase<T>::normalized_similarity<Sentence2>(const Sentence2 &,double,double) const”的引用
1>        with
1>        [
1>            T=rapidfuzz::CachedLevenshtein<wchar_t>,
1>            Sentence2=std::wstring
1>        ]
1>c:\users\11737\source\repos\consoleapplication1\filename.cpp(17): note: 参见对正在编译的函数 模板 实例化“double rapidfuzz::detail::CachedNormalizedMetricBase<T>::normalized_similarity<Sentence2>(const Sentence2 &,double,double) const”的引用
1>        with
1>        [
1>            T=rapidfuzz::CachedLevenshtein<wchar_t>,
1>            Sentence2=std::wstring
1>        ]
1>c:\users\11737\source\repos\consoleapplication1\filename.cpp(26): note: 参见对正在编译的函数 模板 实例化“double levenshtein_normalized_similarity<std::wstring,std::wstring>(const Sentence1 &,const Sentence2 &,rapidfuzz::LevenshteinWeightTable,double)”的引用
1>        with
1>        [
1>            Sentence1=std::wstring,
1>            Sentence2=std::wstring
1>        ]
1>c:\users\11737\documents\github\rapidfuzz-cpp\rapidfuzz\distance\levenshtein_impl.hpp(731): error C2530: “res_”: 必须初始化引用
1>c:\users\11737\documents\github\rapidfuzz-cpp\rapidfuzz\distance\levenshtein_impl.hpp(732): error C3536: “res_”: 初始化之前无法使用
1>c:\users\11737\documents\github\rapidfuzz-cpp\rapidfuzz\distance\levenshtein_impl.hpp(732): error C2065: “row”: 未声明的标识符
1>c:\users\11737\documents\github\rapidfuzz-cpp\rapidfuzz\distance\levenshtein_impl.hpp(732): error C2065: “first_block”: 未声明的标识符
1>c:\users\11737\documents\github\rapidfuzz-cpp\rapidfuzz\distance\levenshtein_impl.hpp(733): error C2065: “row”: 未声明的标识符
1>c:\users\11737\documents\github\rapidfuzz-cpp\rapidfuzz\distance\levenshtein_impl.hpp(733): error C2065: “first_block”: 未声明的标识符
1>已完成生成项目“ConsoleApplication1.vcxproj”的操作 - 失败。
========== “全部重新生成”: 0 成功，1 失败，0已跳过 ==========
========== 重新生成 于 15:40 完成，耗时 01.210 秒 ==========

