### PR TITLE
Mark functions as inline when constexpr not available

### DIFF
--- a/rapidfuzz/details/config.hpp
+++ b/rapidfuzz/details/config.hpp
@@ -15,5 +15,5 @@
 #if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201402L) || __cplusplus >= 201402L)
 #    define RAPIDFUZZ_CONSTEXPR_CXX14 constexpr
 #else
-#    define RAPIDFUZZ_CONSTEXPR_CXX14
+#    define RAPIDFUZZ_CONSTEXPR_CXX14 inline
 #endif


### PR DESCRIPTION
Hi @maxbachmann, thanks again for #119! I think I've got everything working in C++11 now, but I had to make this one more change to avoid multiple definition issues pre-C++14. Please let me know if this is correct, I mostly based it on this: https://stackoverflow.com/questions/14391272/does-constexpr-imply-inline