### PR TITLE
Use range in cmake_minimum

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Cmake config largely taken from catch2
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5..3.24)
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
   cmake_policy(SET CMP0135 NEW)


### PR DESCRIPTION
Resolves the following deprecation warning I got when building with CMake 3.31.5:

```
CMake Deprecation Warning at CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```