### PR TITLE
Use quotes rather than brackets on internal includes

### DIFF
--- a/bench/bench-fuzz.cpp
+++ b/bench/bench-fuzz.cpp
@@ -1,5 +1,5 @@
-#include <benchmark/benchmark.h>
-#include <rapidfuzz/fuzz.hpp>
+#include "benchmark/benchmark.h"
+#include "rapidfuzz/fuzz.hpp"
 #include <string>
 #include <vector>
 

--- a/bench/bench-jarowinkler.cpp
+++ b/bench/bench-jarowinkler.cpp
@@ -1,6 +1,6 @@
-#include <benchmark/benchmark.h>
+#include "benchmark/benchmark.h"
 #include <random>
-#include <rapidfuzz/distance/Jaro.hpp>
+#include "rapidfuzz/distance/Jaro.hpp"
 #include <string>
 #include <vector>
 

--- a/bench/bench-lcs.cpp
+++ b/bench/bench-lcs.cpp
@@ -1,7 +1,7 @@
-#include <benchmark/benchmark.h>
+#include "benchmark/benchmark.h"
 #include <random>
-#include <rapidfuzz/details/intrinsics.hpp>
-#include <rapidfuzz/distance/LCSseq.hpp>
+#include "rapidfuzz/details/intrinsics.hpp"
+#include "rapidfuzz/distance/LCSseq.hpp"
 #include <string>
 #include <vector>
 

--- a/bench/bench-levenshtein.cpp
+++ b/bench/bench-levenshtein.cpp
@@ -1,6 +1,6 @@
-#include <benchmark/benchmark.h>
+#include "benchmark/benchmark.h"
 #include <random>
-#include <rapidfuzz/distance/Levenshtein.hpp>
+#include "rapidfuzz/distance/Levenshtein.hpp"
 #include <string>
 #include <vector>
 

--- a/fuzzing/fuzz_damerau_levenshtein_distance.cpp
+++ b/fuzzing/fuzz_damerau_levenshtein_distance.cpp
@@ -3,8 +3,8 @@
 
 #include "../rapidfuzz_reference/DamerauLevenshtein.hpp"
 #include "fuzzing.hpp"
-#include <rapidfuzz/details/Range.hpp>
-#include <rapidfuzz/distance/DamerauLevenshtein.hpp>
+#include "rapidfuzz/details/Range.hpp"
+#include "rapidfuzz/distance/DamerauLevenshtein.hpp"
 #include <stdexcept>
 #include <string>
 

--- a/fuzzing/fuzz_indel_distance.cpp
+++ b/fuzzing/fuzz_indel_distance.cpp
@@ -4,7 +4,7 @@
 #include "../rapidfuzz_reference/Indel.hpp"
 #include "fuzzing.hpp"
 #include <limits>
-#include <rapidfuzz/distance/Indel.hpp>
+#include "rapidfuzz/distance/Indel.hpp"
 #include <stdexcept>
 #include <string>
 

--- a/fuzzing/fuzz_indel_editops.cpp
+++ b/fuzzing/fuzz_indel_editops.cpp
@@ -3,7 +3,7 @@
 
 #include "../rapidfuzz_reference/Indel.hpp"
 #include "fuzzing.hpp"
-#include <rapidfuzz/distance.hpp>
+#include "rapidfuzz/distance.hpp"
 #include <stdexcept>
 #include <string>
 

--- a/fuzzing/fuzz_jaro_similarity.cpp
+++ b/fuzzing/fuzz_jaro_similarity.cpp
@@ -3,8 +3,8 @@
 
 #include "../rapidfuzz_reference/Jaro.hpp"
 #include "fuzzing.hpp"
-#include <rapidfuzz/details/Range.hpp>
-#include <rapidfuzz/distance/Jaro.hpp>
+#include "rapidfuzz/details/Range.hpp"
+#include "rapidfuzz/distance/Jaro.hpp"
 #include <stdexcept>
 #include <string>
 

--- a/fuzzing/fuzz_lcs_similarity.cpp
+++ b/fuzzing/fuzz_lcs_similarity.cpp
@@ -3,8 +3,8 @@
 
 #include "../rapidfuzz_reference/LCSseq.hpp"
 #include "fuzzing.hpp"
-#include <rapidfuzz/details/Range.hpp>
-#include <rapidfuzz/distance/LCSseq.hpp>
+#include "rapidfuzz/details/Range.hpp"
+#include "rapidfuzz/distance/LCSseq.hpp"
 #include <stdexcept>
 #include <string>
 

--- a/fuzzing/fuzz_levenshtein_distance.cpp
+++ b/fuzzing/fuzz_levenshtein_distance.cpp
@@ -3,8 +3,8 @@
 
 #include "../rapidfuzz_reference/Levenshtein.hpp"
 #include "fuzzing.hpp"
-#include <rapidfuzz/details/Range.hpp>
-#include <rapidfuzz/distance/Levenshtein.hpp>
+#include "rapidfuzz/details/Range.hpp"
+#include "rapidfuzz/distance/Levenshtein.hpp"
 #include <stdexcept>
 #include <string>
 

--- a/fuzzing/fuzz_levenshtein_editops.cpp
+++ b/fuzzing/fuzz_levenshtein_editops.cpp
@@ -3,7 +3,7 @@
 
 #include "../rapidfuzz_reference/Levenshtein.hpp"
 #include "fuzzing.hpp"
-#include <rapidfuzz/distance.hpp>
+#include "rapidfuzz/distance.hpp"
 #include <stdexcept>
 #include <string>
 

--- a/fuzzing/fuzz_osa_distance.cpp
+++ b/fuzzing/fuzz_osa_distance.cpp
@@ -3,8 +3,8 @@
 
 #include "../rapidfuzz_reference/OSA.hpp"
 #include "fuzzing.hpp"
-#include <rapidfuzz/details/Range.hpp>
-#include <rapidfuzz/distance/OSA.hpp>
+#include "rapidfuzz/details/Range.hpp"
+#include "rapidfuzz/distance/OSA.hpp"
 #include <stdexcept>
 #include <string>
 

--- a/fuzzing/fuzz_partial_ratio.cpp
+++ b/fuzzing/fuzz_partial_ratio.cpp
@@ -4,7 +4,7 @@
 #include "../rapidfuzz_reference/fuzz.hpp"
 #include "fuzzing.hpp"
 #include <cstdint>
-#include <rapidfuzz/fuzz.hpp>
+#include "rapidfuzz/fuzz.hpp"
 #include <stdexcept>
 #include <string>
 

--- a/fuzzing/fuzzing.hpp
+++ b/fuzzing/fuzzing.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include <iostream>
-#include <rapidfuzz/distance/Levenshtein.hpp>
+#include "rapidfuzz/distance/Levenshtein.hpp"
 #include <vector>
 
 static inline bool extract_strings(const uint8_t* data, size_t size, std::vector<uint8_t>& s1,

--- a/rapidfuzz/details/PatternMatchVector.hpp
+++ b/rapidfuzz/details/PatternMatchVector.hpp
@@ -6,10 +6,10 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include <rapidfuzz/details/GrowingHashmap.hpp>
-#include <rapidfuzz/details/Matrix.hpp>
-#include <rapidfuzz/details/Range.hpp>
-#include <rapidfuzz/details/intrinsics.hpp>
+#include "rapidfuzz/details/GrowingHashmap.hpp"
+#include "rapidfuzz/details/Matrix.hpp"
+#include "rapidfuzz/details/Range.hpp"
+#include "rapidfuzz/details/intrinsics.hpp"
 
 namespace rapidfuzz {
 namespace detail {

--- a/rapidfuzz/details/Range.hpp
+++ b/rapidfuzz/details/Range.hpp
@@ -13,7 +13,7 @@
 #include <sys/types.h>
 #include <vector>
 
-#include <rapidfuzz/details/type_traits.hpp>
+#include "rapidfuzz/details/type_traits.hpp"
 
 namespace rapidfuzz {
 namespace detail {

--- a/rapidfuzz/details/SplittedSentenceView.hpp
+++ b/rapidfuzz/details/SplittedSentenceView.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <algorithm>
-#include <rapidfuzz/details/Range.hpp>
-#include <rapidfuzz/details/type_traits.hpp>
+#include "rapidfuzz/details/Range.hpp"
+#include "rapidfuzz/details/type_traits.hpp"
 
 namespace rapidfuzz {
 namespace detail {

--- a/rapidfuzz/details/common.hpp
+++ b/rapidfuzz/details/common.hpp
@@ -3,11 +3,11 @@
 
 #pragma once
 #include <cstring>
-#include <rapidfuzz/details/Range.hpp>
-#include <rapidfuzz/details/SplittedSentenceView.hpp>
-#include <rapidfuzz/details/intrinsics.hpp>
-#include <rapidfuzz/details/type_traits.hpp>
-#include <rapidfuzz/details/types.hpp>
+#include "rapidfuzz/details/Range.hpp"
+#include "rapidfuzz/details/SplittedSentenceView.hpp"
+#include "rapidfuzz/details/intrinsics.hpp"
+#include "rapidfuzz/details/type_traits.hpp"
+#include "rapidfuzz/details/types.hpp"
 
 #if defined(__APPLE__) && !defined(_LIBCPP_HAS_C11_FEATURES)
 #    include <mm_malloc.h>
@@ -98,4 +98,4 @@ static inline void rf_aligned_free(void* ptr)
 } // namespace detail
 } // namespace rapidfuzz
 
-#include <rapidfuzz/details/common_impl.hpp>
+#include "rapidfuzz/details/common_impl.hpp"

--- a/rapidfuzz/details/distance.hpp
+++ b/rapidfuzz/details/distance.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <cmath>
-#include <rapidfuzz/details/Range.hpp>
-#include <rapidfuzz/details/common.hpp>
-#include <rapidfuzz/details/simd.hpp>
+#include "rapidfuzz/details/Range.hpp"
+#include "rapidfuzz/details/common.hpp"
+#include "rapidfuzz/details/simd.hpp"
 #include <type_traits>
 
 namespace rapidfuzz {

--- a/rapidfuzz/details/intrinsics.hpp
+++ b/rapidfuzz/details/intrinsics.hpp
@@ -7,7 +7,7 @@
 #include <cassert>
 #include <cstddef>
 #include <limits>
-#include <rapidfuzz/details/config.hpp>
+#include "rapidfuzz/details/config.hpp"
 #include <stdint.h>
 #include <type_traits>
 

--- a/rapidfuzz/details/simd.hpp
+++ b/rapidfuzz/details/simd.hpp
@@ -10,12 +10,12 @@
 #        define RAPIDFUZZ_SIMD
 #        define RAPIDFUZZ_AVX2
 #        define RAPIDFUZZ_LTO_HACK 0
-#        include <rapidfuzz/details/simd_avx2.hpp>
+#        include "rapidfuzz/details/simd_avx2.hpp"
 
 #    elif (defined(_M_AMD64) || defined(_M_X64)) || defined(__SSE2__)
 #        define RAPIDFUZZ_SIMD
 #        define RAPIDFUZZ_SSE2
 #        define RAPIDFUZZ_LTO_HACK 1
-#        include <rapidfuzz/details/simd_sse2.hpp>
+#        include "rapidfuzz/details/simd_sse2.hpp"
 #    endif
 #endif

--- a/rapidfuzz/details/simd_avx2.hpp
+++ b/rapidfuzz/details/simd_avx2.hpp
@@ -5,7 +5,7 @@
 #include <array>
 #include <immintrin.h>
 #include <ostream>
-#include <rapidfuzz/details/intrinsics.hpp>
+#include "rapidfuzz/details/intrinsics.hpp"
 #include <stdint.h>
 
 namespace rapidfuzz {

--- a/rapidfuzz/details/simd_sse2.hpp
+++ b/rapidfuzz/details/simd_sse2.hpp
@@ -5,7 +5,7 @@
 #include <array>
 #include <emmintrin.h>
 #include <ostream>
-#include <rapidfuzz/details/intrinsics.hpp>
+#include "rapidfuzz/details/intrinsics.hpp"
 #include <stdint.h>
 
 namespace rapidfuzz {

--- a/rapidfuzz/details/type_traits.hpp
+++ b/rapidfuzz/details/type_traits.hpp
@@ -2,7 +2,7 @@
 /* Copyright © 2020 Max Bachmann */
 
 #pragma once
-#include <rapidfuzz/details/types.hpp>
+#include "rapidfuzz/details/types.hpp"
 
 #include <iterator>
 #include <utility>

--- a/rapidfuzz/details/types.hpp
+++ b/rapidfuzz/details/types.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <algorithm>
-#include <rapidfuzz/details/config.hpp>
+#include "rapidfuzz/details/config.hpp"
 #include <stddef.h>
 #include <stdexcept>
 #include <vector>

--- a/rapidfuzz/distance.hpp
+++ b/rapidfuzz/distance.hpp
@@ -2,16 +2,16 @@
 /* Copyright © 2022-present Max Bachmann */
 
 #pragma once
-#include <rapidfuzz/distance/DamerauLevenshtein.hpp>
-#include <rapidfuzz/distance/Hamming.hpp>
-#include <rapidfuzz/distance/Indel.hpp>
-#include <rapidfuzz/distance/Jaro.hpp>
-#include <rapidfuzz/distance/JaroWinkler.hpp>
-#include <rapidfuzz/distance/LCSseq.hpp>
-#include <rapidfuzz/distance/Levenshtein.hpp>
-#include <rapidfuzz/distance/OSA.hpp>
-#include <rapidfuzz/distance/Postfix.hpp>
-#include <rapidfuzz/distance/Prefix.hpp>
+#include "rapidfuzz/distance/DamerauLevenshtein.hpp"
+#include "rapidfuzz/distance/Hamming.hpp"
+#include "rapidfuzz/distance/Indel.hpp"
+#include "rapidfuzz/distance/Jaro.hpp"
+#include "rapidfuzz/distance/JaroWinkler.hpp"
+#include "rapidfuzz/distance/LCSseq.hpp"
+#include "rapidfuzz/distance/Levenshtein.hpp"
+#include "rapidfuzz/distance/OSA.hpp"
+#include "rapidfuzz/distance/Postfix.hpp"
+#include "rapidfuzz/distance/Prefix.hpp"
 
 namespace rapidfuzz {
 

--- a/rapidfuzz/distance/DamerauLevenshtein.hpp
+++ b/rapidfuzz/distance/DamerauLevenshtein.hpp
@@ -2,7 +2,7 @@
 /* Copyright © 2022-present Max Bachmann */
 
 #include <algorithm>
-#include <rapidfuzz/distance/DamerauLevenshtein_impl.hpp>
+#include "rapidfuzz/distance/DamerauLevenshtein_impl.hpp"
 
 namespace rapidfuzz {
 /* the API will require a change when adding custom weights */

--- a/rapidfuzz/distance/DamerauLevenshtein_impl.hpp
+++ b/rapidfuzz/distance/DamerauLevenshtein_impl.hpp
@@ -5,11 +5,11 @@
 #include <cstddef>
 #include <limits>
 #include <numeric>
-#include <rapidfuzz/details/GrowingHashmap.hpp>
-#include <rapidfuzz/details/Matrix.hpp>
-#include <rapidfuzz/details/Range.hpp>
-#include <rapidfuzz/details/common.hpp>
-#include <rapidfuzz/details/distance.hpp>
+#include "rapidfuzz/details/GrowingHashmap.hpp"
+#include "rapidfuzz/details/Matrix.hpp"
+#include "rapidfuzz/details/Range.hpp"
+#include "rapidfuzz/details/common.hpp"
+#include "rapidfuzz/details/distance.hpp"
 
 namespace rapidfuzz {
 namespace detail {

--- a/rapidfuzz/distance/Hamming.hpp
+++ b/rapidfuzz/distance/Hamming.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 #include <limits>
-#include <rapidfuzz/details/common.hpp>
-#include <rapidfuzz/distance/Hamming_impl.hpp>
+#include "rapidfuzz/details/common.hpp"
+#include "rapidfuzz/distance/Hamming_impl.hpp"
 
 namespace rapidfuzz {
 

--- a/rapidfuzz/distance/Hamming_impl.hpp
+++ b/rapidfuzz/distance/Hamming_impl.hpp
@@ -2,8 +2,8 @@
 /* Copyright © 2021 Max Bachmann */
 
 #pragma once
-#include <rapidfuzz/details/Range.hpp>
-#include <rapidfuzz/details/distance.hpp>
+#include "rapidfuzz/details/Range.hpp"
+#include "rapidfuzz/details/distance.hpp"
 #include <stdexcept>
 
 namespace rapidfuzz {

--- a/rapidfuzz/distance/Indel.hpp
+++ b/rapidfuzz/distance/Indel.hpp
@@ -4,8 +4,8 @@
 #pragma once
 
 #include <limits>
-#include <rapidfuzz/distance/Indel_impl.hpp>
-#include <rapidfuzz/distance/LCSseq.hpp>
+#include "rapidfuzz/distance/Indel_impl.hpp"
+#include "rapidfuzz/distance/LCSseq.hpp"
 
 namespace rapidfuzz {
 

--- a/rapidfuzz/distance/Indel_impl.hpp
+++ b/rapidfuzz/distance/Indel_impl.hpp
@@ -1,12 +1,12 @@
 /* SPDX-License-Identifier: MIT */
 /* Copyright © 2022-present Max Bachmann */
 
-#include <rapidfuzz/details/PatternMatchVector.hpp>
-#include <rapidfuzz/details/Range.hpp>
-#include <rapidfuzz/details/common.hpp>
-#include <rapidfuzz/details/distance.hpp>
-#include <rapidfuzz/details/intrinsics.hpp>
-#include <rapidfuzz/distance/LCSseq.hpp>
+#include "rapidfuzz/details/PatternMatchVector.hpp"
+#include "rapidfuzz/details/Range.hpp"
+#include "rapidfuzz/details/common.hpp"
+#include "rapidfuzz/details/distance.hpp"
+#include "rapidfuzz/details/intrinsics.hpp"
+#include "rapidfuzz/distance/LCSseq.hpp"
 
 namespace rapidfuzz {
 namespace detail {

--- a/rapidfuzz/distance/Jaro.hpp
+++ b/rapidfuzz/distance/Jaro.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <rapidfuzz/details/Range.hpp>
-#include <rapidfuzz/distance/Jaro_impl.hpp>
+#include "rapidfuzz/details/Range.hpp"
+#include "rapidfuzz/distance/Jaro_impl.hpp"
 #include <stdlib.h>
 
 namespace rapidfuzz {

--- a/rapidfuzz/distance/JaroWinkler.hpp
+++ b/rapidfuzz/distance/JaroWinkler.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <rapidfuzz/details/Range.hpp>
-#include <rapidfuzz/distance/JaroWinkler_impl.hpp>
+#include "rapidfuzz/details/Range.hpp"
+#include "rapidfuzz/distance/JaroWinkler_impl.hpp"
 
 namespace rapidfuzz {
 

--- a/rapidfuzz/distance/JaroWinkler_impl.hpp
+++ b/rapidfuzz/distance/JaroWinkler_impl.hpp
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: MIT */
 /* Copyright © 2022-present Max Bachmann */
 
-#include <rapidfuzz/distance/Jaro.hpp>
+#include "rapidfuzz/distance/Jaro.hpp"
 
 namespace rapidfuzz {
 namespace detail {

--- a/rapidfuzz/distance/Jaro_impl.hpp
+++ b/rapidfuzz/distance/Jaro_impl.hpp
@@ -3,10 +3,10 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <rapidfuzz/details/PatternMatchVector.hpp>
-#include <rapidfuzz/details/common.hpp>
-#include <rapidfuzz/details/distance.hpp>
-#include <rapidfuzz/details/intrinsics.hpp>
+#include "rapidfuzz/details/PatternMatchVector.hpp"
+#include "rapidfuzz/details/common.hpp"
+#include "rapidfuzz/details/distance.hpp"
+#include "rapidfuzz/details/intrinsics.hpp"
 #include <vector>
 
 namespace rapidfuzz {

--- a/rapidfuzz/distance/LCSseq.hpp
+++ b/rapidfuzz/distance/LCSseq.hpp
@@ -2,7 +2,7 @@
 /* Copyright © 2022-present Max Bachmann */
 
 #pragma once
-#include <rapidfuzz/distance/LCSseq_impl.hpp>
+#include "rapidfuzz/distance/LCSseq_impl.hpp"
 
 #include <algorithm>
 #include <limits>

--- a/rapidfuzz/distance/LCSseq_impl.hpp
+++ b/rapidfuzz/distance/LCSseq_impl.hpp
@@ -2,16 +2,16 @@
 /* Copyright © 2022-present Max Bachmann */
 
 #include <limits>
-#include <rapidfuzz/details/Matrix.hpp>
-#include <rapidfuzz/details/PatternMatchVector.hpp>
-#include <rapidfuzz/details/common.hpp>
-#include <rapidfuzz/details/distance.hpp>
-#include <rapidfuzz/details/intrinsics.hpp>
-#include <rapidfuzz/details/simd.hpp>
+#include "rapidfuzz/details/Matrix.hpp"
+#include "rapidfuzz/details/PatternMatchVector.hpp"
+#include "rapidfuzz/details/common.hpp"
+#include "rapidfuzz/details/distance.hpp"
+#include "rapidfuzz/details/intrinsics.hpp"
+#include "rapidfuzz/details/simd.hpp"
 
 #include <algorithm>
 #include <array>
-#include <rapidfuzz/details/types.hpp>
+#include "rapidfuzz/details/types.hpp"
 
 namespace rapidfuzz {
 namespace detail {

--- a/rapidfuzz/distance/Levenshtein.hpp
+++ b/rapidfuzz/distance/Levenshtein.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 #include <limits>
-#include <rapidfuzz/details/Range.hpp>
-#include <rapidfuzz/distance/Levenshtein_impl.hpp>
+#include "rapidfuzz/details/Range.hpp"
+#include "rapidfuzz/distance/Levenshtein_impl.hpp"
 
 namespace rapidfuzz {
 

--- a/rapidfuzz/distance/Levenshtein_impl.hpp
+++ b/rapidfuzz/distance/Levenshtein_impl.hpp
@@ -4,14 +4,14 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
-#include <rapidfuzz/details/GrowingHashmap.hpp>
-#include <rapidfuzz/details/Matrix.hpp>
-#include <rapidfuzz/details/PatternMatchVector.hpp>
-#include <rapidfuzz/details/common.hpp>
-#include <rapidfuzz/details/distance.hpp>
-#include <rapidfuzz/details/intrinsics.hpp>
-#include <rapidfuzz/details/type_traits.hpp>
-#include <rapidfuzz/distance/Indel.hpp>
+#include "rapidfuzz/details/GrowingHashmap.hpp"
+#include "rapidfuzz/details/Matrix.hpp"
+#include "rapidfuzz/details/PatternMatchVector.hpp"
+#include "rapidfuzz/details/common.hpp"
+#include "rapidfuzz/details/distance.hpp"
+#include "rapidfuzz/details/intrinsics.hpp"
+#include "rapidfuzz/details/type_traits.hpp"
+#include "rapidfuzz/distance/Indel.hpp"
 #include <sys/types.h>
 
 namespace rapidfuzz {

--- a/rapidfuzz/distance/OSA.hpp
+++ b/rapidfuzz/distance/OSA.hpp
@@ -4,8 +4,8 @@
 #pragma once
 
 #include <limits>
-#include <rapidfuzz/details/common.hpp>
-#include <rapidfuzz/distance/OSA_impl.hpp>
+#include "rapidfuzz/details/common.hpp"
+#include "rapidfuzz/distance/OSA_impl.hpp"
 
 namespace rapidfuzz {
 

--- a/rapidfuzz/distance/OSA_impl.hpp
+++ b/rapidfuzz/distance/OSA_impl.hpp
@@ -4,11 +4,11 @@
 
 #pragma once
 #include <cstdint>
-#include <rapidfuzz/details/PatternMatchVector.hpp>
-#include <rapidfuzz/details/Range.hpp>
-#include <rapidfuzz/details/common.hpp>
-#include <rapidfuzz/details/distance.hpp>
-#include <rapidfuzz/details/simd.hpp>
+#include "rapidfuzz/details/PatternMatchVector.hpp"
+#include "rapidfuzz/details/Range.hpp"
+#include "rapidfuzz/details/common.hpp"
+#include "rapidfuzz/details/distance.hpp"
+#include "rapidfuzz/details/simd.hpp"
 
 namespace rapidfuzz {
 namespace detail {

--- a/rapidfuzz/distance/Postfix.hpp
+++ b/rapidfuzz/distance/Postfix.hpp
@@ -4,8 +4,8 @@
 #pragma once
 
 #include <limits>
-#include <rapidfuzz/details/common.hpp>
-#include <rapidfuzz/distance/Postfix_impl.hpp>
+#include "rapidfuzz/details/common.hpp"
+#include "rapidfuzz/distance/Postfix_impl.hpp"
 
 namespace rapidfuzz {
 

--- a/rapidfuzz/distance/Postfix_impl.hpp
+++ b/rapidfuzz/distance/Postfix_impl.hpp
@@ -2,9 +2,9 @@
 /* Copyright © 2021 Max Bachmann */
 
 #pragma once
-#include <rapidfuzz/details/Range.hpp>
-#include <rapidfuzz/details/common.hpp>
-#include <rapidfuzz/details/distance.hpp>
+#include "rapidfuzz/details/Range.hpp"
+#include "rapidfuzz/details/common.hpp"
+#include "rapidfuzz/details/distance.hpp"
 
 namespace rapidfuzz {
 namespace detail {

--- a/rapidfuzz/distance/Prefix.hpp
+++ b/rapidfuzz/distance/Prefix.hpp
@@ -4,8 +4,8 @@
 #pragma once
 
 #include <limits>
-#include <rapidfuzz/details/common.hpp>
-#include <rapidfuzz/distance/Prefix_impl.hpp>
+#include "rapidfuzz/details/common.hpp"
+#include "rapidfuzz/distance/Prefix_impl.hpp"
 
 namespace rapidfuzz {
 

--- a/rapidfuzz/distance/Prefix_impl.hpp
+++ b/rapidfuzz/distance/Prefix_impl.hpp
@@ -2,9 +2,9 @@
 /* Copyright © 2021 Max Bachmann */
 
 #pragma once
-#include <rapidfuzz/details/Range.hpp>
-#include <rapidfuzz/details/common.hpp>
-#include <rapidfuzz/details/distance.hpp>
+#include "rapidfuzz/details/Range.hpp"
+#include "rapidfuzz/details/common.hpp"
+#include "rapidfuzz/details/distance.hpp"
 
 namespace rapidfuzz {
 namespace detail {

--- a/rapidfuzz/fuzz.hpp
+++ b/rapidfuzz/fuzz.hpp
@@ -3,10 +3,10 @@
 /* Copyright © 2011 Adam Cohen */
 
 #pragma once
-#include <rapidfuzz/details/CharSet.hpp>
-#include <rapidfuzz/details/PatternMatchVector.hpp>
-#include <rapidfuzz/details/common.hpp>
-#include <rapidfuzz/distance/Indel.hpp>
+#include "rapidfuzz/details/CharSet.hpp"
+#include "rapidfuzz/details/PatternMatchVector.hpp"
+#include "rapidfuzz/details/common.hpp"
+#include "rapidfuzz/distance/Indel.hpp"
 
 namespace rapidfuzz {
 namespace fuzz {
@@ -808,4 +808,4 @@ CachedQRatio(InputIt1 first1, InputIt1 last1) -> CachedQRatio<iter_value_t<Input
 } // namespace fuzz
 } // namespace rapidfuzz
 
-#include <rapidfuzz/fuzz_impl.hpp>
+#include "rapidfuzz/fuzz_impl.hpp"

--- a/rapidfuzz/fuzz_impl.hpp
+++ b/rapidfuzz/fuzz_impl.hpp
@@ -4,7 +4,7 @@
 
 #include "rapidfuzz/details/Range.hpp"
 #include <limits>
-#include <rapidfuzz/details/CharSet.hpp>
+#include "rapidfuzz/details/CharSet.hpp"
 
 #include <algorithm>
 #include <cmath>

--- a/rapidfuzz/rapidfuzz_all.hpp
+++ b/rapidfuzz/rapidfuzz_all.hpp
@@ -2,5 +2,5 @@
 /* Copyright © 2022-present Max Bachmann */
 
 #pragma once
-#include <rapidfuzz/distance.hpp>
-#include <rapidfuzz/fuzz.hpp>
+#include "rapidfuzz/distance.hpp"
+#include "rapidfuzz/fuzz.hpp"


### PR DESCRIPTION
I'm mostly pattern-matching here and don't quite understand why these were using brackets in the first place, but it seems as though the DuckDB amalgamation logic depends on `<` being used for standard library and `"` being used for local files.